### PR TITLE
bossa: update to 1.7.0 version to pickup port argument fix

### DIFF
--- a/recipes-hosttools/bossa/bossa_git.bb
+++ b/recipes-hosttools/bossa/bossa_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=94411054a7f6921218ab9c05b6b4b15b"
 DEPENDS = "readline"
 
 PR = "r0"
-SRCREV = "ce82a9fac4b916e359fb003ee4d19afc0ff01c90"
+SRCREV = "5cae9fee241bd3c95c197b2464e9b83240994c43"
 SRC_URI = "git://github.com/femtoio/BOSSA.git;protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The -p option assumed a "/dev" prefix in v1.6.1 version.  The 1.7.0
fixes that to try the argument passed via -p assuming its a fully
qualified path, and if that fails defaults back to appending the
"/dev" prefix.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>