### PR TITLE
Revert "meta-zephyr-sdk: disable MIPS"

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -10,6 +10,7 @@ env:
         - SDK_TARGET=arm
         - SDK_TARGET=iamcu
         - SDK_TARGET=arc
+        - SDK_TARGET=mips
         - SDK_TARGET=nios2
         - SDK_TARGET=riscv32
 

--- a/scripts/meta-zephyr-sdk-build-split.sh
+++ b/scripts/meta-zephyr-sdk-build-split.sh
@@ -187,19 +187,21 @@ cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
 header "Building x86 toolchain...done"
 fi
 
+if [ "$1" = "mips" ]; then
 #  build MIPS toolchain
-#header "Building MIPS toolchain..."
-#newbuild build-zephyr-mips  > /dev/null
-#setconf_var "MACHINE" "qemumips" $localconf
-#setconf_var "TCLIBC" "baremetal" $localconf
-#setconf_var "TOOLCHAIN_TARGET_TASK_append" " newlib" $localconf
-#rm -f ./tmp/deploy/sdk/*.sh
-#bitbake meta-toolchain -c clean  > /dev/null
-#bitbake meta-toolchain
-#[ $? -ne 0 ] && echo "Error(s) encountered during bitbake." && exit 1
-#cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
-#[ $? -ne 0 ] && exit 1
-#header "Building MIPS toolchain...done"
+header "Building MIPS toolchain..."
+newbuild build-zephyr-mips  > /dev/null
+setconf_var "MACHINE" "qemumips" $localconf
+setconf_var "TCLIBC" "baremetal" $localconf
+setconf_var "TOOLCHAIN_TARGET_TASK_append" " newlib" $localconf
+rm -f ./tmp/deploy/sdk/*.sh
+bitbake meta-toolchain -c clean  > /dev/null
+bitbake meta-toolchain
+[ $? -ne 0 ] && echo "Error(s) encountered during bitbake." && exit 1
+cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
+[ $? -ne 0 ] && exit 1
+header "Building MIPS toolchain...done"
+fi
 
 if [ "$1" = "arc" ]; then
 # build ARC toolchain...

--- a/scripts/meta-zephyr-sdk-build.sh
+++ b/scripts/meta-zephyr-sdk-build.sh
@@ -177,18 +177,18 @@ cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
 header "Building x86 toolchain...done"
 
 #  build MIPS toolchain
-#header "Building MIPS toolchain..."
-#newbuild build-zephyr-mips  > /dev/null
-#setconf_var "MACHINE" "qemumips" $localconf
-#setconf_var "TCLIBC" "baremetal" $localconf
-#setconf_var "TOOLCHAIN_TARGET_TASK_append" " newlib" $localconf
-#rm -f ./tmp/deploy/sdk/*.sh
-#bitbake meta-toolchain -c clean  > /dev/null
-#bitbake meta-toolchain
-#[ $? -ne 0 ] && echo "Error(s) encountered during bitbake." && exit 1
-#cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
-#[ $? -ne 0 ] && exit 1
-#header "Building MIPS toolchain...done"
+header "Building MIPS toolchain..."
+newbuild build-zephyr-mips  > /dev/null
+setconf_var "MACHINE" "qemumips" $localconf
+setconf_var "TCLIBC" "baremetal" $localconf
+setconf_var "TOOLCHAIN_TARGET_TASK_append" " newlib" $localconf
+rm -f ./tmp/deploy/sdk/*.sh
+bitbake meta-toolchain -c clean  > /dev/null
+bitbake meta-toolchain
+[ $? -ne 0 ] && echo "Error(s) encountered during bitbake." && exit 1
+cp ./tmp/deploy/sdk/*.sh $TOOLCHAINS
+[ $? -ne 0 ] && exit 1
+header "Building MIPS toolchain...done"
 
 # build ARC toolchain...
 header "Building ARC toolchain..."


### PR DESCRIPTION
This reverts commit c16d77c751dc922e82327d220d973dac1ad75a78.

Re-enable MIPS toolschains as we have seem interest in getting MIPS
support into Zephyr.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>