### PR TITLE
Several toolchain fixes/updates

### DIFF
--- a/recipes-devtools/gcc/gcc-cross-canadian_6.%.bbappend
+++ b/recipes-devtools/gcc/gcc-cross-canadian_6.%.bbappend
@@ -1,2 +1,3 @@
 
+EXTRA_OECONF_append = " --with-gnu-as "
 EXTRA_OECONF_append_libc-baremetal = " --enable-plugin"

--- a/recipes-devtools/qemu/zephyr-qemu-riscv_git.bb
+++ b/recipes-devtools/qemu/zephyr-qemu-riscv_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=c04def7ae38850e7d3ef548588159913"
 
 SRCREV = "b12cfa344681687c7adbc5fa66590182df3748b9"
-SRC_URI = "git://github.com/riscv/riscv-qemu.git;protocol=https "
+SRC_URI = "git://github.com/riscv/riscv-qemu.git;protocol=https;nobranch=1"
 
 BBCLASSEXTEND = "native nativesdk"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"

--- a/recipes-kernel/dtc/dtc_git.bbappend
+++ b/recipes-kernel/dtc/dtc_git.bbappend
@@ -1,0 +1,8 @@
+SRCREV = "e54388015af1fb4bf04d0bca99caba1074d9cc42"
+PV = "1.4.6"
+
+do_install () {
+        oe_runmake install NO_PYTHON=1
+}
+
+FILES_${PN}-misc_append = "${bindir}/fdtoverlay ${bindir}/fdtput ${bindir}/fdtget"


### PR DESCRIPTION
* Fixed issue with qemu on riscv32 not being able to be fetched for build
* Updated dtc to 1.4.6 to get improved warnings and support for multiple labels on a node
* Build gcc with --with-gnu-as so when we try and compile a .S with gcc, include path's, etc get passed down properly to gas.