### PR TITLE
gdb (xtensa): fix interaction with QEMU gdbserver

### DIFF
--- a/recipes-devtools/gdb/files/0001-gdb-xtensa-handle-privileged-registers.patch
+++ b/recipes-devtools/gdb/files/0001-gdb-xtensa-handle-privileged-registers.patch
@@ -1,0 +1,71 @@
+From ad6b2e6258cc6eb7b5f5d7de282a12b15a0f6590 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Wed, 25 Apr 2018 11:55:56 -0700
+Subject: [PATCH] gdb: xtensa: handle privileged registers
+
+gdb/
+2018-04-25  Max Filippov  <jcmvbkbc@gmail.com>
+
+	* xtensa-linux-tdep.c (xtensa-tdep.h): New include.
+	(xtensa_linux_init_abi): Limit tdep->num_regs by
+	tdep->num_nopriv_regs.
+	* xtensa-tdep.c (xtensa_derive_tdep): Calculate
+	tdep->num_nopriv_regs and only copy it to tdep->num_regs if it's
+	not initialized.
+---
+ gdb/xtensa-linux-tdep.c |  6 ++++++
+ gdb/xtensa-tdep.c       | 12 ++++--------
+ 2 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/gdb/xtensa-linux-tdep.c b/gdb/xtensa-linux-tdep.c
+index a9b30c73f7bf..b62085de2fcb 100644
+--- a/gdb/xtensa-linux-tdep.c
++++ b/gdb/xtensa-linux-tdep.c
+@@ -18,6 +18,7 @@
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+ 
+ #include "defs.h"
++#include "xtensa-tdep.h"
+ #include "osabi.h"
+ #include "linux-tdep.h"
+ #include "solib-svr4.h"
+@@ -97,6 +98,11 @@ xtensa_linux_gdb_signal_to_target (struct gdbarch *gdbarch,
+ static void
+ xtensa_linux_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch)
+ {
++  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
++
++  if (tdep->num_nopriv_regs < tdep->num_regs)
++    tdep->num_regs = tdep->num_nopriv_regs;
++
+   linux_init_abi (info, gdbarch);
+ 
+   set_solib_svr4_fetch_link_map_offsets
+diff --git a/gdb/xtensa-tdep.c b/gdb/xtensa-tdep.c
+index a1ecf5f56a42..01f96165dc8d 100644
+--- a/gdb/xtensa-tdep.c
++++ b/gdb/xtensa-tdep.c
+@@ -3145,16 +3145,12 @@ xtensa_derive_tdep (struct gdbarch_tdep *tdep)
+ 	max_size = rmap->byte_size;
+       if (rmap->mask != 0 && tdep->num_regs == 0)
+ 	tdep->num_regs = n;
+-      /* Find out out how to deal with priveleged registers.
+-
+-         if ((rmap->flags & XTENSA_REGISTER_FLAGS_PRIVILEGED) != 0
+-              && tdep->num_nopriv_regs == 0)
+-           tdep->num_nopriv_regs = n;
+-      */
+       if ((rmap->flags & XTENSA_REGISTER_FLAGS_PRIVILEGED) != 0
+-	  && tdep->num_regs == 0)
+-	tdep->num_regs = n;
++	  && tdep->num_nopriv_regs == 0)
++	tdep->num_nopriv_regs = n;
+     }
++  if (tdep->num_regs == 0)
++    tdep->num_regs = tdep->num_nopriv_regs;
+ 
+   /* Number of pseudo registers.  */
+   tdep->num_pseudo_regs = n - tdep->num_regs;
+-- 
+2.11.0
+

--- a/recipes-devtools/gdb/gdb-cross-canadian_7.%.bbappend
+++ b/recipes-devtools/gdb/gdb-cross-canadian_7.%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://Add-Intel-MCU-support-to-gdb.patch"
+SRC_URI += "file://0001-gdb-xtensa-handle-privileged-registers.patch"
 
 EXTRA_OECONF_remove = "--disable-tui"
 EXTRA_OECONF_append = " --enable-tui"


### PR DESCRIPTION
Hello,

this change allows gdb to correctly access privileged xtensa registers exposed by QEMU over its gdbserver and fixes issue #4309 in zephyrproject-rtos (https://github.com/zephyrproject-rtos/zephyr/issues/4309).