### PR TITLE
dtc: Update dtc post 1.4.7

### DIFF
--- a/recipes-kernel/dtc/dtc_git.bbappend
+++ b/recipes-kernel/dtc/dtc_git.bbappend
@@ -1,5 +1,6 @@
-SRCREV = "e54388015af1fb4bf04d0bca99caba1074d9cc42"
-PV = "1.4.6"
+SRCREV = "1e4a0928f3b3b827824222572e551a60935607e3"
+PV = "1.4.7+git"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 do_install () {
         oe_runmake install NO_PYTHON=1

--- a/recipes-kernel/dtc/files/make_install.patch
+++ b/recipes-kernel/dtc/files/make_install.patch
@@ -1,0 +1,26 @@
+From e9852b9d206df1e42aa4c8afec55a0f5e099b533 Mon Sep 17 00:00:00 2001
+From: Saul Wold <sgw@linux.intel.com>
+Date: Thu, 3 Nov 2011 08:35:47 -0700
+Subject: [PATCH] dtc: Add patch to correctly install shared libraries and
+
+Upstream-Status: Inappropriate [configuration]
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d8ebc4f..f5e01be 100644
+--- a/Makefile
++++ b/Makefile
+@@ -205,8 +205,8 @@ install-bin: all $(SCRIPTS)
+ install-lib: all
+ 	@$(VECHO) INSTALL-LIB
+ 	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
+-	$(INSTALL_LIB) $(LIBFDT_lib) $(DESTDIR)$(LIBDIR)
+-	ln -sf $(notdir $(LIBFDT_lib)) $(DESTDIR)$(LIBDIR)/$(LIBFDT_soname)
++	$(INSTALL) $(LIBFDT_lib) $(DESTDIR)$(LIBDIR)/$(LIBFDT_soname)
++	ln -sf $(LIBFDT_soname) $(DESTDIR)$(LIBDIR)/$(notdir $(LIBFDT_lib))
+ 	ln -sf $(LIBFDT_soname) $(DESTDIR)$(LIBDIR)/libfdt.$(SHAREDLIB_EXT)
+ 	$(INSTALL_DATA) $(LIBFDT_archive) $(DESTDIR)$(LIBDIR)
+ 


### PR DESCRIPTION
Pull in dtc version c86da84d30e4b72cfb4fee22b62bea4257bc14bf which
is post the 1.4.7 release.  This gets the new YAML generation support

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>